### PR TITLE
HTML opzet navigatie profielen

### DIFF
--- a/myapp/src/routes/+page.server.js
+++ b/myapp/src/routes/+page.server.js
@@ -1,14 +1,14 @@
 
 // hier laden we directus data voor alle pagina's
 export async function load ({url, params}) {
-    const memberResponse = await fetch('https://fdnd.directus.app/items/personhttps://fdnd.directus.app/items/person?fields=*,squads.squad_id.name,squads.squad_id.cohort,squads.squad_id.tribe.name&filter[squads][squad_id][cohort][_eq]=2526&filter[squads][squad_id][tribe][name][_eq]=FDND%20Jaar%202')
+    const memberResponse = await fetch('https://fdnd.directus.app/items/person?fields=*,squads.squad_id.name,squads.squad_id.cohort,squads.squad_id.tribe.name&filter[squads][squad_id][cohort][_eq]=2526&filter[squads][squad_id][tribe][name][_eq]=FDND%20Jaar%202')
 
 
 
     const memberData = await memberResponse.json();
 
-    console.log(memberData)
-    return { member: memberData.data}
+    // console.log(memberData)
+    return { members: memberData.data}
     
 }
 

--- a/myapp/src/routes/+page.svelte
+++ b/myapp/src/routes/+page.svelte
@@ -1,22 +1,25 @@
 <script>
-    export let data;
-  const { localData, memberData } = data // hier word de lokale json data opgehaald en directus data
-  </script>
-  
+  export let data;
+  const { localData } = data // hier word de lokale json data opgehaald en directus data
+  const members=data.members
+  console.log(members)
+</script>
+
 <h1>Welcome to SvelteKit</h1>
 <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
 
 <h2>Lokaal JSON</h2>
-  <ul>
-    {#each localData.data as item}
-      <li>{item.name}</li>
-      <img src={item.profilepicture} alt={item.name} width="80" />
-    {/each}
-  </ul>
+<ul>
+  {#each localData.data as item}
+    <li>{item.name}</li>
+    <img src={item.profilepicture} alt={item.name} width="80" />
+  {/each}
+</ul>
 
 <h2>Directus data</h2>
 {#each members as member}
 <p>{member.name}</p>
+<p>{member.bio}</p>
 {/each}
 
 

--- a/myapp/src/routes/profilenav/+page.svelte
+++ b/myapp/src/routes/profilenav/+page.svelte
@@ -1,0 +1,36 @@
+<script>
+    export let data;
+    const { localData } = data // hier word de lokale json data opgehaald en directus data
+    const members=data.members
+    console.log(members)
+</script>
+  
+<h1>Squads</h1>
+
+<article>
+    <!-- filter voor squads -->
+    <form>
+        <fielset>
+            <legend>Select a squad</legend>
+            <input type="radio" name="squad" value="e">
+            <label for="">squad E</label>
+            <input type="radio" name="squad" value="f">
+            <label for="">squad F</label>
+        </fielset>
+    </form>
+
+    <!-- Nayome: Hier kan je werken aan de knoppen -->
+    <!-- menu van profielfoto's -->
+    <ul>
+        {#each localData.data as item}
+            <li>
+                <button>
+                    <img src={item.profilepicture} alt={item.name} width="80"/>
+                </button>
+            </li>
+        {/each}
+    </ul>
+
+    <!-- Selecteerd een willekeurig profiel -->
+    <button>random</button>
+</article>

--- a/myapp/src/routes/profilenav/+page.svelte
+++ b/myapp/src/routes/profilenav/+page.svelte
@@ -7,15 +7,15 @@
   
 <h1>Squads</h1>
 
-<article>
+<div>
     <!-- filter voor squads -->
     <form>
         <fielset>
             <legend>Select a squad</legend>
             <input type="radio" name="squad" value="e">
-            <label for="">squad E</label>
+            <label for="squad-e">squad E</label>
             <input type="radio" name="squad" value="f">
-            <label for="">squad F</label>
+            <label for="squad-f">squad F</label>
         </fielset>
     </form>
 
@@ -25,7 +25,7 @@
         {#each localData.data as item}
             <li>
                 <button>
-                    <img src={item.profilepicture} alt={item.name} width="80"/>
+                    <img src={item.profilepicture} alt={item.name} width="80" />
                 </button>
             </li>
         {/each}
@@ -33,4 +33,4 @@
 
     <!-- Selecteerd een willekeurig profiel -->
     <button>random</button>
-</article>
+</div>

--- a/myapp/svelte.config.js
+++ b/myapp/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-netlify';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
## wat heb ik gedaan?

In deze pull request heb ik de map: 'profilenav' en daarin de pagina: +page.svelte aangemaakt. Hierin staat een HTML opzet met de navigatie van de profielen. 

commit: e4639eb8e826186be4174d0975ad2e6f76af56be
issue: #6 

Ook heb ik enkele kleine aanpassingen gemaakt in de overige bestanden omdat ik een error kreeg bij het ophalen van de data. 

1. Bij het ophalen van de data stonden 2 linkjes aan elkaar, die heb ik vervangen naar 1 link 
2. Heb het script iets aangepast zodat het makkelijker te debuggen is aangezien de data niet correct inlaadde
3. Een specifieke adapter toegevoegd zodat de verkeerde niet wordt geselecteerd

commit: 01311852c9a6fd1ccc4d7f8d04236e30f763b4c9

## Visueel voorbeeld
<img width="321" height="735" alt="image" src="https://github.com/user-attachments/assets/de2cda91-d8eb-4010-857d-2e53c1ca09ce" />

## Uitgevoerde testen
- HTML validator test

## Ik ontvang graag feedback op
- Comments in code, is alles duidelijk? 
- Is mijn HTML structuur goed (staan er geen fouten in)?

@yamenAl @Nayomekaia 